### PR TITLE
Update regex that extracts app version

### DIFF
--- a/internal/constants/version_default.go
+++ b/internal/constants/version_default.go
@@ -44,7 +44,7 @@ func getNewestAppVersion() (string, error) {
 	}
 
 	finalURL := resp.Request.URL.String()
-	re := regexp.MustCompile(`tag\/(\d+\.\d+\.\d+)`)
+	re := regexp.MustCompile(`tag\/v?(\d+\.\d+\.\d+)`)
 	matches := re.FindStringSubmatch(finalURL)
 	if len(matches) < 2 {
 		return "", errors.New("no version found in redirect URL")


### PR DESCRIPTION
Their latest tag ([v7.0.10](https://github.com/ProtonMail/android-mail/releases/tag/v7.0.10)) is prefixed with a `v`, so this takes that into account.

Before this:

```
$ protonmail-bridge
...
time="2025-09-25T13:53:37-03:00" level=warning msg="Failed to get newest app version" error="no version found in redirect URL"
WARN[Sep 25 13:53:37.726] Failed to get newest app version              error="no version found in redirect URL"
WARN[Sep 25 13:53:38.156] Failed to get newest app version              error="no version found in redirect URL"
...
WARN[Sep 25 13:53:38.850] 400 POST https://mail.proton.me/api/auth/v4/refresh: Invalid version number (``) (Code=2064, Status=400), Attempt 1  pkg=gpa/client
```